### PR TITLE
Filter table schema case insensitive

### DIFF
--- a/src/main/java/com/bjoernkw/schematic/TablesController.java
+++ b/src/main/java/com/bjoernkw/schematic/TablesController.java
@@ -118,7 +118,7 @@ public class TablesController {
 
     private List<Table> getTables() {
         List<Table> tables = jdbcTemplate.query(
-                "SELECT table_name FROM INFORMATION_SCHEMA.Tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'",
+                "SELECT table_name FROM INFORMATION_SCHEMA.Tables WHERE lower(table_schema) = 'public' AND table_type = 'BASE TABLE'",
                 new BeanPropertyRowMapper<>(Table.class)
         );
         tables.forEach(table -> {


### PR DESCRIPTION
I finally got around to test out Schematic and was irriated I couldn't see any tables while still using an embedded H2.

This is just a rudimentary lowercasing of the `TABLE_SCHEMA` values for matching against `public`. I don't know this will suffice for many more databases.

A quick thought which came into my mind was a user configurable alternate schema settable in `SchematicProperties` if the need arises. (Not for me, yet.)

Nice little project! (stumbled upon while researching for htmx :))